### PR TITLE
Add memo edit page

### DIFF
--- a/lib/models/memo.dart
+++ b/lib/models/memo.dart
@@ -8,6 +8,8 @@ class Memo {
   late String shopName;
   late DateTime tappedOn;
   late List<String> keywords;
+  late String keywordsString;
   late int score;
+  late String purchaceStore;
   late String body;
 }

--- a/lib/widgets/memo_edit_page.dart
+++ b/lib/widgets/memo_edit_page.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:uchi_sake/models/memo.dart';
+
+class MemoEditPage extends StatefulWidget {
+  const MemoEditPage({Key? key}) : super(key: key);
+
+  @override
+  State<MemoEditPage> createState() => _MemoEditPageState();
+}
+
+class _MemoEditPageState extends State<MemoEditPage> {
+  late Memo memo;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('飲んだお酒のメモ'),
+      ),
+      body: const Text('TODO'),
+    );
+  }
+}

--- a/lib/widgets/memo_edit_page.dart
+++ b/lib/widgets/memo_edit_page.dart
@@ -13,11 +13,61 @@ class _MemoEditPageState extends State<MemoEditPage> {
 
   @override
   Widget build(BuildContext context) {
+    memo = Memo();
+    memo.name = 'おさけのなまえ';
+    memo.purchaceStore = 'なんとか酒店';
+    memo.keywordsString = '日本酒 純米 原酒 辛口';
+    memo.body = 'たいへん美味しかった！';
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('飲んだお酒のメモ'),
-      ),
-      body: const Text('TODO'),
-    );
+        appBar: AppBar(
+          title: const Text('飲んだお酒のメモ'),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(children: [
+            TextFormField(
+              initialValue: memo.name,
+              key: const ValueKey('memoNameTextField'),
+              decoration: const InputDecoration(
+                labelText: '名前',
+              ),
+              onChanged: (value) {
+                // TODO: 保存
+              },
+            ),
+            TextFormField(
+              initialValue: memo.purchaceStore,
+              key: const ValueKey('memoPurchaseStoreTextField'),
+              decoration: const InputDecoration(
+                labelText: '買ったお店',
+              ),
+              onChanged: (value) {
+                // TODO: 保存
+              },
+            ),
+            TextFormField(
+              initialValue: memo.keywordsString,
+              key: const ValueKey('memoKeywordsStringTextField'),
+              decoration: const InputDecoration(
+                labelText: 'キーワード',
+              ),
+              onChanged: (value) {
+                // TODO: 保存
+              },
+            ),
+            TextFormField(
+              initialValue: memo.body,
+              key: const ValueKey('memoBodyTextField'),
+              decoration: const InputDecoration(
+                labelText: 'メモ',
+              ),
+              maxLines: 15,
+              onChanged: (value) {
+                // TODO: 保存
+              },
+            ),
+          ]),
+        ));
   }
 }

--- a/lib/widgets/memo_list_page.dart
+++ b/lib/widgets/memo_list_page.dart
@@ -28,7 +28,7 @@ class _MemoListPageState extends State<MemoListPage> {
     }
   }
 
-  void _createMemo() async {
+  void _createMemo(BuildContext context) async {
     await Navigator.push(
         context,
         MaterialPageRoute(
@@ -96,7 +96,7 @@ class _MemoListPageState extends State<MemoListPage> {
               );
             }).toList()),
       floatingActionButton: FloatingActionButton(
-        onPressed: _createMemo,
+        onPressed: () => _createMemo(context),
         tooltip: 'メモを追加します。',
         child: const Icon(Icons.add),
       ),

--- a/lib/widgets/memo_list_page.dart
+++ b/lib/widgets/memo_list_page.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: unnecessary_const
-
 import 'package:flutter/material.dart';
 import 'package:uchi_sake/models/memo.dart';
 
@@ -11,7 +9,7 @@ class MemoListPage extends StatefulWidget {
 }
 
 class _MemoListPageState extends State<MemoListPage> {
-  static const star = const Icon(
+  static const star = Icon(
     Icons.star,
     color: Color.fromRGBO(253, 216, 53, 1),
     size: 15,

--- a/lib/widgets/memo_list_page.dart
+++ b/lib/widgets/memo_list_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:uchi_sake/models/memo.dart';
+import 'package:uchi_sake/widgets/memo_edit_page.dart';
 
 class MemoListPage extends StatefulWidget {
   const MemoListPage({Key? key}) : super(key: key);
@@ -27,8 +28,13 @@ class _MemoListPageState extends State<MemoListPage> {
     }
   }
 
-  void _createMemo() {
-    // TODO: 新規メモ作成ページを表示
+  void _createMemo() async {
+    await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => const MemoEditPage(),
+        ));
+    setState(() {});
   }
 
   @override


### PR DESCRIPTION
一覧から+ボタンで、メモの編集画面を表示するようにしました。
編集画面は↓の簡単なコントロールでできるもののみ配置しています。

- 名前
- 購入店
- キーワード
- メモ

![image](https://user-images.githubusercontent.com/2942348/164237629-f8526deb-f561-409f-a4f3-e1b0c51ee9c4.png)

