### PR TITLE
tmpを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,8 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
+# テンポラリ
+tmp/*
+
 # Isarライブラリ
 libisar.dylib


### PR DESCRIPTION
テスト時にこのディレクトリを作成しますが、
構成管理化に置く必要がないので、無視リストに追加します。