### PR TITLE
編集ページを開いたときに評価が表示されなかった問題を修正

### DIFF
--- a/lib/widgets/memo_edit_page.dart
+++ b/lib/widgets/memo_edit_page.dart
@@ -200,7 +200,7 @@ class _MemoEditPageState extends State<MemoEditPage> {
                 ),
               ),
               RatingBar.builder(
-                initialRating: 0,
+                initialRating: memo.score?.toDouble() ?? 0,
                 minRating: 0,
                 maxRating: 3,
                 direction: Axis.horizontal,


### PR DESCRIPTION
編集ページを開いたときに評価が表示されていませんでした。
初期値を0固定にしていたのが問題でした。