### PR TITLE
開栓日がnullでも今日の日付を表示していた

### DIFF
--- a/lib/widgets/memo_edit_page.dart
+++ b/lib/widgets/memo_edit_page.dart
@@ -29,8 +29,7 @@ class _MemoEditPageState extends State<MemoEditPage> {
           child: ListView(
             children: [
               InkWell(
-                child: Text(
-                    "開栓日 ${dateTime2yyyymmdd(memo.tappedOn ?? DateTime.now())}"),
+                child: Text("開栓日 ${dateTime2yyyymmdd(memo.tappedOn)}"),
                 onTap: () async {
                   DateTime? picked = await _selectDate(memo, context);
                   if (picked != null) {


### PR DESCRIPTION
開栓日に記入をしていないのに、今日の日付を表示していました。
これだと入力忘れが起きるので、表示しないように修正します。