### PR TITLE
Fix #31

### DIFF
--- a/lib/widgets/memo_edit_page.dart
+++ b/lib/widgets/memo_edit_page.dart
@@ -6,7 +6,7 @@ import 'package:uchi_sake/helpers.dart';
 import 'package:uchi_sake/models/memo.dart';
 
 class MemoEditPage extends StatefulWidget {
-  final Memo? memo;
+  final Memo memo;
   const MemoEditPage(this.memo, {Key? key}) : super(key: key);
 
   @override
@@ -18,7 +18,7 @@ class _MemoEditPageState extends State<MemoEditPage> {
 
   @override
   Widget build(BuildContext context) {
-    Memo memo = widget.memo ?? Memo();
+    Memo memo = widget.memo;
 
     return Scaffold(
         appBar: AppBar(

--- a/lib/widgets/memo_list_page.dart
+++ b/lib/widgets/memo_list_page.dart
@@ -15,7 +15,7 @@ class MemoListPage extends StatefulWidget {
 class _MemoListPageState extends State<MemoListPage> {
   List<Memo> memos = [];
 
-  void _openMemo(Memo? memo, BuildContext context) async {
+  void _openMemo(Memo memo, BuildContext context) async {
     await Navigator.push(
         context,
         MaterialPageRoute(
@@ -118,7 +118,7 @@ class _MemoListPageState extends State<MemoListPage> {
               );
             }).toList()),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => _openMemo(null, context),
+        onPressed: () => _openMemo(Memo(), context),
         tooltip: 'メモを追加します。',
         child: const Icon(Icons.add),
       ),

--- a/test/widgets/memo_edit_page_test.dart
+++ b/test/widgets/memo_edit_page_test.dart
@@ -8,18 +8,18 @@ import 'package:uchi_sake/widgets/memo_edit_page.dart';
 
 void main() {
   wrapTest(() {
-    group('memo = nullのとき', () {
-      const Memo? memo = null;
-      const memoEditPage = MemoEditPage(memo);
+    group('memo = 未保存のとき', () {
+      Memo memo = Memo();
+      MemoEditPage memoEditPage = MemoEditPage(memo);
 
       testWidgets('ページが表示されていること', (WidgetTester tester) async {
-        await tester.pumpWidget(const MaterialApp(home: memoEditPage));
+        await tester.pumpWidget(MaterialApp(home: memoEditPage));
 
         expect(find.text('飲んだお酒のメモ'), findsOneWidget);
       });
 
       testWidgets('記入後に自動的に保存されていること', (WidgetTester tester) async {
-        await tester.pumpWidget(const MaterialApp(home: memoEditPage));
+        await tester.pumpWidget(MaterialApp(home: memoEditPage));
         await tester.enterText(
             find.byKey(const ValueKey('memoNameTextField')), 'お酒の名前');
         // await tester.enterText(


### PR DESCRIPTION
新規作成の場合、編集ページのbuild時に生成していました。
カレンダーのような非同期のウィンドウを使って
値を取得しようとしたときに、buildが動いて新しくインスタンスを生成してしまっていました。

新規レコードの際もページ作成時にインスタンスを渡すように修正しました。