### PR TITLE
名前の一部からメモを検索できるようにする

### DIFF
--- a/lib/models/memo.dart
+++ b/lib/models/memo.dart
@@ -46,4 +46,13 @@ class Memo {
       });
     }
   }
+
+  static List<Memo> searchByText(String searchText) {
+    return isar.memos
+        .where(sort: Sort.desc)
+        .anyTappedOn()
+        .filter()
+        .nameContains(searchText)
+        .findAllSync();
+  }
 }

--- a/lib/widgets/memo_list_page.dart
+++ b/lib/widgets/memo_list_page.dart
@@ -57,6 +57,7 @@ class _MemoListPageState extends State<MemoListPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('飲んだお酒のメモ'),
+        actions: [IconButton(onPressed: () {}, icon: const Icon(Icons.search))],
       ),
       body: memos.isEmpty
           ? Center(

--- a/lib/widgets/memo_list_page.dart
+++ b/lib/widgets/memo_list_page.dart
@@ -4,6 +4,7 @@ import 'package:uchi_sake/common.dart';
 import 'package:uchi_sake/models/memo.dart';
 import 'package:uchi_sake/widgets/memo_edit_page.dart';
 import 'package:uchi_sake/widgets/memo_card.dart';
+import 'package:uchi_sake/widgets/memo_search_page.dart';
 
 class MemoListPage extends StatefulWidget {
   const MemoListPage({Key? key}) : super(key: key);
@@ -57,7 +58,18 @@ class _MemoListPageState extends State<MemoListPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('飲んだお酒のメモ'),
-        actions: [IconButton(onPressed: () {}, icon: const Icon(Icons.search))],
+        actions: [
+          IconButton(
+              onPressed: () async {
+                await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const MemoSearchPage(),
+                    ));
+                setState(() {});
+              },
+              icon: const Icon(Icons.search))
+        ],
       ),
       body: memos.isEmpty
           ? Center(

--- a/lib/widgets/memo_search_page.dart
+++ b/lib/widgets/memo_search_page.dart
@@ -49,6 +49,7 @@ class _MemoSearchPageState extends State<MemoSearchPage> {
           this.searchText = searchText;
         });
       },
+      key: const ValueKey('searchTextField'),
     );
   }
 

--- a/lib/widgets/memo_search_page.dart
+++ b/lib/widgets/memo_search_page.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:isar/isar.dart';
-import 'package:uchi_sake/common.dart';
 import 'package:uchi_sake/models/memo.dart';
 import 'package:uchi_sake/widgets/memo_card.dart';
 import 'package:uchi_sake/widgets/memo_edit_page.dart';
@@ -17,12 +15,7 @@ class _MemoSearchPageState extends State<MemoSearchPage> {
 
   @override
   Widget build(BuildContext context) {
-    List<Memo> memos = isar.memos
-        .where(sort: Sort.desc)
-        .anyTappedOn()
-        .filter()
-        .nameContains(searchText)
-        .findAllSync();
+    List<Memo> memos = Memo.searchByText(searchText);
 
     return Scaffold(
       appBar: AppBar(title: _searchTextField()),

--- a/lib/widgets/memo_search_page.dart
+++ b/lib/widgets/memo_search_page.dart
@@ -13,10 +13,16 @@ class MemoSearchPage extends StatefulWidget {
 }
 
 class _MemoSearchPageState extends State<MemoSearchPage> {
+  String searchText = '';
+
   @override
   Widget build(BuildContext context) {
-    List<Memo> memos =
-        isar.memos.where(sort: Sort.desc).anyTappedOn().findAllSync();
+    List<Memo> memos = isar.memos
+        .where(sort: Sort.desc)
+        .anyTappedOn()
+        .filter()
+        .nameContains(searchText)
+        .findAllSync();
 
     return Scaffold(
       appBar: AppBar(title: _searchTextField()),
@@ -39,12 +45,17 @@ class _MemoSearchPageState extends State<MemoSearchPage> {
   }
 
   Widget _searchTextField() {
-    return const TextField(
+    return TextField(
       autofocus: true,
       textInputAction: TextInputAction.search,
-      decoration: InputDecoration(
+      decoration: const InputDecoration(
         hintText: '検索',
       ),
+      onSubmitted: (String searchText) {
+        setState(() {
+          this.searchText = searchText;
+        });
+      },
     );
   }
 

--- a/lib/widgets/memo_search_page.dart
+++ b/lib/widgets/memo_search_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class MemoSearchPage extends StatefulWidget {
+  const MemoSearchPage({Key? key}) : super(key: key);
+
+  @override
+  State<MemoSearchPage> createState() => _MemoSearchPageState();
+}
+
+class _MemoSearchPageState extends State<MemoSearchPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(title: const Text('検索')),
+        body: Center(
+          child: Column(children: const [Text('みつかりません')]),
+        ));
+  }
+}

--- a/lib/widgets/memo_search_page.dart
+++ b/lib/widgets/memo_search_page.dart
@@ -1,4 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:isar/isar.dart';
+import 'package:uchi_sake/common.dart';
+import 'package:uchi_sake/models/memo.dart';
+import 'package:uchi_sake/widgets/memo_card.dart';
+import 'package:uchi_sake/widgets/memo_edit_page.dart';
 
 class MemoSearchPage extends StatefulWidget {
   const MemoSearchPage({Key? key}) : super(key: key);
@@ -10,11 +15,27 @@ class MemoSearchPage extends StatefulWidget {
 class _MemoSearchPageState extends State<MemoSearchPage> {
   @override
   Widget build(BuildContext context) {
+    List<Memo> memos =
+        isar.memos.where(sort: Sort.desc).anyTappedOn().findAllSync();
+
     return Scaffold(
-        appBar: AppBar(title: _searchTextField()),
-        body: Center(
-          child: Column(children: const [Text('みつかりません')]),
-        ));
+      appBar: AppBar(title: _searchTextField()),
+      body: memos.isEmpty
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: const <Widget>[
+                  Text('まだありません。'),
+                ],
+              ),
+            )
+          : ListView(
+              children: memos.map((Memo memo) {
+              return MemoCard(memo,
+                  onTap: () => _openMemo(memo, context),
+                  onLongPress: () => _deleteMemo(memo, context));
+            }).toList()),
+    );
   }
 
   Widget _searchTextField() {
@@ -25,5 +46,40 @@ class _MemoSearchPageState extends State<MemoSearchPage> {
         hintText: '検索',
       ),
     );
+  }
+
+  void _openMemo(Memo memo, BuildContext context) async {
+    await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => MemoEditPage(memo),
+        ));
+    setState(() {});
+  }
+
+  void _deleteMemo(Memo memo, BuildContext context) {
+    showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) {
+          return AlertDialog(
+            content: Text('「${memo.name}」を削除しますか？'),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('いいえ'),
+              ),
+              TextButton(
+                onPressed: () async {
+                  setState(() {
+                    memo.destroy();
+                  });
+                  Navigator.of(context).pop();
+                },
+                child: const Text('はい'),
+              )
+            ],
+          );
+        });
   }
 }

--- a/lib/widgets/memo_search_page.dart
+++ b/lib/widgets/memo_search_page.dart
@@ -11,9 +11,19 @@ class _MemoSearchPageState extends State<MemoSearchPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(title: const Text('検索')),
+        appBar: AppBar(title: _searchTextField()),
         body: Center(
           child: Column(children: const [Text('みつかりません')]),
         ));
+  }
+
+  Widget _searchTextField() {
+    return const TextField(
+      autofocus: true,
+      textInputAction: TextInputAction.search,
+      decoration: InputDecoration(
+        hintText: '検索',
+      ),
+    );
   }
 }

--- a/test/models/memo_test.dart
+++ b/test/models/memo_test.dart
@@ -125,5 +125,52 @@ void main() {
         });
       });
     });
+
+    group('#searchText', () {
+      List<Memo> memos = [];
+
+      var memoSake = Memo()..name = '日本酒';
+      var memoRedWine = Memo()..name = '赤ワイン';
+      var memoWhiteWine = Memo()..name = '白ワイン';
+
+      setUp(() {
+        memoSake.save();
+        memoRedWine.save();
+        memoWhiteWine.save();
+        memos.add(memoSake);
+        memos.add(memoRedWine);
+        memos.add(memoWhiteWine);
+      });
+
+      group('searchText = ""のとき', () {
+        test('すべてのメモが返されること', () {
+          var ret = Memo.searchByText('');
+          var ids = ret.map((memo) => memo.id).toList();
+          for (var memo in memos) {
+            expect(ids.contains(memo.id), isTrue);
+          }
+        });
+      });
+
+      group('searchText = "酒"のとき', () {
+        test('memoSakeが返されること', () {
+          var ret = Memo.searchByText('酒');
+          var ids = ret.map((memo) => memo.id).toList();
+          expect(ids.contains(memoSake.id), isTrue);
+          expect(ids.contains(memoRedWine.id), isFalse);
+          expect(ids.contains(memoWhiteWine.id), isFalse);
+        });
+      });
+
+      group('searchText = "ワイン"のとき', () {
+        test('memoSakeが返されること', () {
+          var ret = Memo.searchByText('ワイン');
+          var ids = ret.map((memo) => memo.id).toList();
+          expect(ids.contains(memoSake.id), isFalse);
+          expect(ids.contains(memoRedWine.id), isTrue);
+          expect(ids.contains(memoWhiteWine.id), isTrue);
+        });
+      });
+    });
   });
 }

--- a/test/widgets/memo_search_page_test.dart
+++ b/test/widgets/memo_search_page_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import '../test_helper.dart';
+import 'package:uchi_sake/models/memo.dart';
+import 'package:uchi_sake/widgets/memo_search_page.dart';
+
+void main() {
+  wrapTest(() {
+    Map<String, Memo> memos = {};
+    const memoSearchPage = MemoSearchPage();
+
+    memos['sake'] = Memo()
+      ..name = '日本酒'
+      ..tappedOn = DateTime.now()
+      ..score = 3
+      ..purchaceStore = "なんとか酒店"
+      ..tappedOn = DateTime.now()
+      ..keywords = ['日本酒', '純米' '原酒' '辛口']
+      ..keywordsString = "日本酒 純米 原酒 辛口"
+      ..body = "今回もたいへん美味しかった！";
+    memos['red_wine'] = Memo()
+      ..name = "赤ワイン"
+      ..tappedOn = DateTime.now()
+      ..score = 3
+      ..purchaceStore = 'リカーショップ・ナントカ'
+      ..tappedOn = DateTime.now()
+      ..keywords = ['ワイン', '赤' 'カベルネ・ソーヴィニヨン' 'フルボディ']
+      ..keywordsString = 'ワイン 赤 カベルネ・ソーヴィニヨン フルボディ'
+      ..body = '今回もたいへん美味しかった！';
+    memos['white_wine'] = Memo()
+      ..name = "白ワイン"
+      ..tappedOn = DateTime.now()
+      ..score = 3
+      ..purchaceStore = 'リカーショップ・ナントカ'
+      ..tappedOn = DateTime.now()
+      ..keywords = ['ワイン', '白' 'シャルドネ' '辛口']
+      ..keywordsString = 'ワイン 白 シャルドネ 辛口'
+      ..body = '今回もたいへん美味しかった！';
+
+    setUp(() {
+      memos.forEach((_key, memo) {
+        memo.save();
+      });
+    });
+
+    testWidgets('「酒」で検索したとき、「日本酒」が表示されること', (WidgetTester tester) async {
+      String searchText = '酒';
+
+      await tester.pumpWidget(const MaterialApp(home: memoSearchPage));
+      await tester.pump();
+      await tester.enterText(
+          find.byKey(const ValueKey('searchTextField')), searchText);
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      expect(find.text(memos['sake']!.name!), findsOneWidget);
+      expect(find.text(memos['red_wine']!.name!), findsNothing);
+      expect(find.text(memos['white_wine']!.name!), findsNothing);
+    });
+
+    testWidgets('「ワイン」で検索したとき、「赤ワイン」と「白ワイン」が表示されること',
+        (WidgetTester tester) async {
+      String searchText = 'ワイン';
+
+      await tester.pumpWidget(const MaterialApp(home: memoSearchPage));
+      await tester.pump();
+      await tester.enterText(
+          find.byKey(const ValueKey('searchTextField')), searchText);
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      expect(find.text(memos['sake']!.name!), findsNothing);
+      expect(find.text(memos['red_wine']!.name!), findsOneWidget);
+      expect(find.text(memos['white_wine']!.name!), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
検索ページで、検索ボックスにテキストを入れたとき、そのテキストが名前に含まれるメモを表示するようにします。

<img width="25%" src="https://user-images.githubusercontent.com/2942348/184533437-571da5a8-5fbc-4bcb-af82-6920cd8b73fb.gif">

## やっていないこと
メモの他の項目からは検索できません。
別のプルリクでやろうと思います。
